### PR TITLE
Spelling fix in documentation

### DIFF
--- a/public/api/extend.html
+++ b/public/api/extend.html
@@ -31,5 +31,5 @@ In other words, all computations are done in ruby, which may seriously
 hurt performance.</p>
 
 <p>Similarly, as <code>extend</code> tends to be a showstopper during compilation, it is
-strongly recommanded to use it as high as possible in query expressions
+strongly recommended to use it as high as possible in query expressions
 trees so as to delegate the largest possible query parts to data engines.</p>

--- a/public/api/restrict.html
+++ b/public/api/restrict.html
@@ -39,4 +39,4 @@ predicate evaluates to TRUE.</p>
 
 <p>As of current Alf version, native predicates (through ruby <code>Proc</code> objects)
 cannot be optimized nor compiled to SQL. The use of predicate factories
-(<code>eq</code>, <code>gt</code>, etc.) is strongly recommanded.</p>
+(<code>eq</code>, <code>gt</code>, etc.) is strongly recommended.</p>

--- a/public/api/summarize.html
+++ b/public/api/summarize.html
@@ -44,5 +44,5 @@ That means that all computations are done in ruby, which may seriously
 hurt performance.</p>
 
 <p>Similarly, as <code>summarize</code> tends to be a showstopper during compilation, it
-is strongly recommanded to use it as high as possible in query expressions
+is strongly recommended to use it as high as possible in query expressions
 trees so as to delegate the largest possible query parts to data engines.</p>

--- a/public/pages/alf-in-ruby.html
+++ b/public/pages/alf-in-ruby.html
@@ -116,7 +116,7 @@ optimization, in-memory implementation. Called on a <code>Relation</code>, a rel
 operator returns a <code>Relation</code>.</p>
 
 <p>For this reason, working with the <code>Relation</code> class is not always a good
-choice. For example, it is not recommanded when you want to incrementally
+choice. For example, it is not recommended when you want to incrementally
 build complex queries against a data source, if you need to avoid loading all
 tuples in memory, or if you want to use logical query optimization.</p>
 


### PR DESCRIPTION
I found a few misspellings of "recommended."
